### PR TITLE
Upgrade compileSDK, dependencies and AGP

### DIFF
--- a/android/airqr/build.gradle
+++ b/android/airqr/build.gradle
@@ -5,11 +5,11 @@ plugins {
     id 'maven-publish'
 }
 android {
-    compileSdk 32
+    compileSdk 34
 
     defaultConfig {
         minSdk 21
-        targetSdk 32
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -32,44 +32,51 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.1.1'
+        kotlinCompilerExtensionVersion '1.5.8'
     }
     packagingOptions {
         resources {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'
         }
     }
+    namespace 'com.mumayank.airqr'
 }
 
 dependencies {
-    implementation 'androidx.core:core-ktx:1.8.0'
-    implementation 'androidx.appcompat:appcompat:1.4.2'
-    implementation 'com.google.android.material:material:1.6.1'
-    testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    // androidx
+    implementation 'androidx.core:core-ktx:1.12.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.11.0'
 
     // jetpack compose
-    implementation "androidx.compose.ui:ui:1.3.0-alpha02"
-    implementation "androidx.compose.material:material:1.3.0-alpha02"
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4:1.2.0"
-    debugImplementation "androidx.compose.ui:ui-tooling:1.2.0"
-    implementation 'androidx.activity:activity-compose:1.5.1'
+    implementation 'androidx.compose.ui:ui:1.5.4'
+    implementation 'androidx.compose.material:material:1.5.4'
+    androidTestImplementation 'androidx.compose.ui:ui-test-junit4:1.5.4'
+    debugImplementation 'androidx.compose.ui:ui-tooling:1.5.4'
+    implementation 'androidx.activity:activity-compose:1.8.2'
+
     // When using a MDC theme
-    implementation "com.google.android.material:compose-theme-adapter:1.1.15"
+    implementation 'com.google.android.material:compose-theme-adapter:1.2.1'
+
     // When using a AppCompat theme
-    implementation "com.google.accompanist:accompanist-appcompat-theme:0.16.0"
-    implementation "androidx.compose.material:material-icons-extended:1.2.0"
-    implementation "com.google.accompanist:accompanist-permissions:0.24.7-alpha"
+    implementation 'com.google.accompanist:accompanist-appcompat-theme:0.32.0'
+    implementation 'androidx.compose.material:material-icons-extended:1.5.4'
+    implementation 'com.google.accompanist:accompanist-permissions:0.32.0'
 
     // jetpack cameraX
-    def camerax_version = "1.2.0-alpha04"
+    def camerax_version = '1.3.1'
     api "androidx.camera:camera-core:${camerax_version}"
     api "androidx.camera:camera-lifecycle:${camerax_version}"
     api "androidx.camera:camera-view:${camerax_version}"
     api "androidx.camera:camera-extensions:${camerax_version}"
+
     // google ml kit barcode scanning
-    api 'com.google.mlkit:barcode-scanning:17.0.2'
+    api 'com.google.mlkit:barcode-scanning:17.2.0'
+
+    // test
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }
 
 afterEvaluate {

--- a/android/airqr/src/main/AndroidManifest.xml
+++ b/android/airqr/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.mumayank.airqr">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-feature android:name="android.hardware.camera.any" />
     <uses-permission android:name="android.permission.CAMERA" />

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -2,13 +2,14 @@ plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
 }
+
 android {
-    compileSdk 32
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.mumayank.airqrandroidproject"
         minSdk 21
-        targetSdk 32
+        targetSdk 34
         versionCode 1
         versionName "1.0"
 
@@ -36,29 +37,37 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.1.1'
+        kotlinCompilerExtensionVersion '1.5.8'
     }
     packagingOptions {
         resources {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'
         }
     }
+    namespace 'com.mumayank.airqrandroidproject'
 }
 
 dependencies {
-    implementation 'androidx.core:core-ktx:1.8.0'
-    implementation 'androidx.appcompat:appcompat:1.4.2'
-    implementation 'com.google.android.material:material:1.6.1'
+    // androidx
+    implementation 'androidx.core:core-ktx:1.12.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'
-    testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.7.0'
+
+    // material design
+    implementation 'com.google.android.material:material:1.11.0'
+
     // jetpack compose
-    implementation "androidx.compose.ui:ui:1.3.0-alpha02"
-    implementation "androidx.compose.ui:ui-tooling-preview:1.2.0"
-    implementation "androidx.compose.material:material:1.3.0-alpha02"
-    implementation 'androidx.activity:activity-compose:1.5.1'
+    implementation 'androidx.compose.ui:ui:1.5.4'
+    implementation 'androidx.compose.ui:ui-tooling-preview:1.5.4'
+    implementation 'androidx.compose.material:material:1.5.4'
+    implementation 'androidx.activity:activity-compose:1.8.2'
+
     // airqr
     implementation(project(":airqr"))
+
+    // test
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.mumayank.airqrandroidproject">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,9 @@
 plugins {
-    id 'com.android.application' version '7.2.1' apply false
-    id 'com.android.library' version '7.2.1' apply false
-    id 'org.jetbrains.kotlin.android' version '1.6.10' apply false
+    id 'com.android.application' version '7.4.2' apply false
+    id 'com.android.library' version '7.4.2' apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.22' apply false
 }
-task clean(type: Delete) {
+
+tasks.register('clean', Delete) {
     delete rootProject.buildDir
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat Apr 16 14:59:20 IST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This commit updates:
- compileSDK to 34,
- AGP to 7.4.2,
- kotlin plugin to 1.9.22

It also updates the compose and cameraX dependencies to their latest versions.